### PR TITLE
Revert "build(deps): bump google-api-python-client from 2.117.0 to 2.122.0"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ ffmpeg_python==0.2.0
 Flask==3.0.2
 Flask_Cors==4.0.0
 g4f==0.2.4.1
-google_api_python_client==2.122.0
+google_api_python_client==2.117.0
 httplib2==0.22.0
 nltk==3.8.1
 oauth2client==4.1.3


### PR DESCRIPTION
Reverts Troptrap/MoneyPrinter-Enhanced#17