### PR TITLE
fix: remove duplicate API call in generate_metadata

### DIFF
--- a/Backend/gpt.py
+++ b/Backend/gpt.py
@@ -448,7 +448,6 @@ def generate_metadata(video_subject: str, script: str, ai_model: str, g4f_model)
 
     description = generate_response(description_prompt, ai_model, g4f_model).strip()
 
-    description = generate_response(description_prompt, ai_model, g4f_model).strip()
 
     # Generate keywords
     keywords = get_search_terms(video_subject, 6, script, ai_model, g4f_model)


### PR DESCRIPTION
Fixed a bug where generate_metadata was calling the API twice for the description. The function was calling generate_response(description_prompt, ai_model, g4f_model).strip() twice, wasting an API call. Removed the duplicate line. — Sent via @AmSach bot