### PR TITLE
fix: remove debug console.log statements

### DIFF
--- a/Frontend/app.js
+++ b/Frontend/app.js
@@ -131,11 +131,9 @@ const cancelGeneration = () => {
 		.then((response) => response.json())
 		.then((data) => {
 			alert(data.message);
-			console.log(data);
 		})
 		.catch((error) => {
 			alert("An error occurred. Please try again later.");
-			console.log(error);
 		});
 
 	// Hide cancel button


### PR DESCRIPTION
Fixed debug console.log statements left in cancelGeneration function. These were logging data and error objects to console in production code which is unnecessary and can leak information. Removed:
- console.log(data) after successful cancel response
- console.log(error) in catch block

— Sent via @AmSach bot