### PR TITLE
fix docker: use bookworm instead of deprecated buster base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-slim-buster
+FROM python:3.11-slim-bookworm
 
 RUN apt-get update && apt-get install --no-install-recommends -y \
     build-essential autoconf pkg-config wget ghostscript curl libpng-dev


### PR DESCRIPTION
Root cause: Debian Buster repos are gone (404), causing apt-get update to fail in CI.
Fix: Update base image from python:3.11-slim-buster to python:3.11-slim-bookworm.